### PR TITLE
Makefile create the hwmon folder if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,6 @@ modules clean:
 install: modules_install
 
 modules_install:
-	cp $(DRIVER).ko $(KERNEL_MODULES)/kernel/$(MOD_SUBDIR)
+	mkdir -p $(KERNEL_MODULES)/kernel/$(MOD_SUBDIR)
+	cp $(DRIVER).ko $(KERNEL_MODULES)/kernel/$(MOD_SUBDIR)/
 	depmod -a -F $(SYSTEM_MAP) $(TARGET)


### PR DESCRIPTION
Not sure how use full this is to other people but since I build a fairly monolithic kernel with most of the modules built in I did not have the drivers/hwmon folder. So when I ran make install the module was copied as drivers/hwmon rather than drivers/hwmon/it87.ko