### PR TITLE
Add optional DKMS target to Makefile (v2)

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+MAKE="make"
+CLEAN="make clean"
+PACKAGE_NAME="it87"
+PACKAGE_VERSION="to be filled by make dkms"
+BUILT_MODULE_NAME[0]="it87"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon/it87"
+AUTOINSTALL="yes"

--- a/it87.c
+++ b/it87.c
@@ -4263,6 +4263,7 @@ module_param(fix_pwm_polarity, bool, 0000);
 MODULE_PARM_DESC(fix_pwm_polarity,
 		 "Force PWM polarity to active high (DANGEROUS)");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(IT87_DRIVER_VERSION);
 
 module_init(sm_it87_init);
 module_exit(sm_it87_exit);


### PR DESCRIPTION
Using DKMS, the driver will be automatically rebuilt when
the kernel is updated.

* `make dkms` to install via DKMS
* `make dkms_clean` to remove from DKMS

This is the second attempt. The first patch failed on the first distribution kernel update because dkms would not replace the packaged module if the version was the same. The difference in this patch is that MODULE_VERSION() is now used to set the module's version to something that can be compared, when previously it was unset. Version is IT87_DRIVER_VERSION, which is probably `git describe --long`. Tested on Ubuntu 17.10.

Having to rebuild the module every time there is a kernel package update is annoying. I think getting dkms to do this is worth trying.