### PR TITLE
Makefile: DKMS fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # For building for the current running version of Linux
+ifndef TARGET
 TARGET		:= $(shell uname -r)
+endif
 # Or specific version
 #TARGET		:= 2.6.33.5
+
 KERNEL_MODULES	:= /lib/modules/$(TARGET)
 
 ifneq ("","$(wildcard /usr/src/linux-headers-$(TARGET)/*)")

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,4 +1,4 @@
-MAKE="make"
+MAKE="make TARGET=${kernelver}"
 CLEAN="make clean"
 PACKAGE_NAME="it87"
 PACKAGE_VERSION="to be filled by make dkms"


### PR DESCRIPTION
Allow DKMS (or anyone) to specify TARGET in Makefile.

Fixes #69 