### PR TITLE
modified for el7 kernel configuration

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -53,7 +53,7 @@ static inline int strict_strtol(const char *cp, unsigned int base, long *res)
  * We still have the functios declared as external, so we can not use
  * static inline.
  */
-#if !defined(CONFIG_HWMON_VID) && !defined(CONFIG_HWMON_VID_MODULE)
+#if !defined(CONFIG_HWMON_VID) || !defined(CONFIG_HWMON_VID_MODULE)
 int vid_from_reg(int val, u8 vrm)
 {
 	return 0;


### PR DESCRIPTION
The Red Hat kernel configuration only knows CONFIG_HWMON_VID. Therefore from my understanding, this entry alternates with CONFIG_HWMON_VID_MODULE.